### PR TITLE
Fix incorrect license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
   name = "karateclub",
   packages = find_packages(),
   version = "1.0.11",
-  license = "MIT",
+  license = "GPLv3",
   description = "A general purpose library for community detection, network embedding, and graph mining research.",
   author = "Benedek Rozemberczki",
   author_email = "benedek.rozemberczki@gmail.com",
@@ -28,7 +28,7 @@ setup(
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3.7",
   ],
 )


### PR DESCRIPTION
The `setup.py` says MIT, but the license file says GPLv3. Fixes the discrepancy. 