### PR TITLE
ego splitter now uses edge weights during community detection

### DIFF
--- a/karateclub/community_detection/overlapping/ego_splitter.py
+++ b/karateclub/community_detection/overlapping/ego_splitter.py
@@ -1,6 +1,6 @@
 import community
 import networkx as nx
-from typing import Dict
+from typing import Dict, Optional
 from karateclub.estimator import Estimator
 
 class EgoNetSplitter(Estimator):
@@ -12,10 +12,12 @@ class EgoNetSplitter(Estimator):
     Args:
         resolution (float): Resolution parameter of Python Louvain. Default 1.0.
         seed (int): Random seed value. Default is 42.
+        weight (str): the key in the graph to use as weight. Default to 'weight'. Specify None to force using an unweighted version of the graph.
     """
-    def __init__(self, resolution: float=1.0, seed: int=42):
+    def __init__(self, resolution: float=1.0, seed: int=42, weight: Optional[str]='weight'):
         self.resolution = resolution
         self.seed = seed
+        self.weight = weight
 
     def _create_egonet(self, node):
         """
@@ -59,20 +61,30 @@ class EgoNetSplitter(Estimator):
         Arg types:
             * **edge** *(list of ints)* - Edge being mapped to the new identifiers.
         """
-        return (self.components[edge[0]][edge[1]], self.components[edge[1]][edge[0]])
+        if self.weight is None or edge[2] is None:
+            return (self.components[edge[0]][edge[1]], self.components[edge[1]][edge[0]])
+        else:
+            return (self.components[edge[0]][edge[1]], self.components[edge[1]][edge[0]], {self.weight: edge[2]})
 
     def _create_persona_graph(self):
         """
         Create a persona graph using the ego-net components.
         """
-        self.persona_graph_edges = [self._get_new_edge_ids(edge) for edge in self.graph.edges()]
+        if self.weight is None:
+            self.persona_graph_edges = [self._get_new_edge_ids(edge) for edge in self.graph.edges()]
+        else:
+            self.persona_graph_edges = [self._get_new_edge_ids(edge) for edge in self.graph.edges(data=self.weight)]
+
         self.persona_graph = nx.from_edgelist(self.persona_graph_edges)
 
     def _create_partitions(self):
         """
         Creating a non-overlapping clustering of nodes in the persona graph.
         """
-        self.partitions = community.best_partition(self.persona_graph, resolution=self.resolution)
+        if self.weight is None:
+            self.partitions = community.best_partition(self.persona_graph, resolution=self.resolution)
+        else:
+            self.partitions = community.best_partition(self.persona_graph, resolution=self.resolution, weight=self.weight)
         self.overlapping_partitions = {node: [] for node in self.graph.nodes()}
         for node, membership in self.partitions.items():
             self.overlapping_partitions[self.personality_map[node]].append(membership)

--- a/test/community_detection_overlapping_test.py
+++ b/test/community_detection_overlapping_test.py
@@ -34,6 +34,35 @@ def test_egonet_splitter():
     assert indices == nodes
     assert type(memberships) == dict
 
+    # Test weighted graph
+    graph = nx.les_miserables_graph()
+    graph = nx.convert_node_labels_to_integers(graph)
+    model = EgoNetSplitter(weight='weight')
+    model.fit(graph)
+    memberships = model.get_memberships()
+    
+    indices = [k for k, v in memberships.items()].sort()
+    nodes = [node for node in graph.nodes()].sort()
+
+    assert graph.number_of_nodes() == len(memberships)
+    assert indices == nodes
+    assert type(memberships) == dict
+
+    # Force unweighted
+    graph = nx.les_miserables_graph()
+    graph = nx.convert_node_labels_to_integers(graph)
+    model = EgoNetSplitter(weight=None)
+    model.fit(graph)
+    memberships = model.get_memberships()
+    
+    indices = [k for k, v in memberships.items()].sort()
+    nodes = [node for node in graph.nodes()].sort()
+
+    assert graph.number_of_nodes() == len(memberships)
+    assert indices == nodes
+    assert type(memberships) == dict
+
+
 
 def test_nnsed():
     """


### PR DESCRIPTION
EgoNetSplitter now takes as a parameter the name of an attribute for edge weights. If the input graph doesn't have edge weights, the default behavior is the same. If the input graph does have edge weights but the desired behavior is to treat the graph as unweighted, specify EgoNetSplitter(weight=None).