### PR TITLE
Fix: making url for Dataset Reader cross-platform

### DIFF
--- a/karateclub/dataset/dataset_reader.py
+++ b/karateclub/dataset/dataset_reader.py
@@ -33,7 +33,7 @@ class GraphReader(object):
         """
         Reading the dataset from the web.
         """
-        path = os.path.join(self.base_url, self.dataset, end)
+        path = f"{self.base_url}{self.dataset}/{end}"
         data = urllib.request.urlopen(path).read()
         data = self._pandas_reader(data)
         return data
@@ -98,7 +98,7 @@ class GraphSetReader(object):
         """
         Reading the dataset from the web.
         """
-        path = os.path.join(self.base_url, self.dataset, end)
+        path = f"{self.base_url}{self.dataset}/{end}"
         data = urllib.request.urlopen(path).read()
         return data
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = ['pytest', 'pytest-cov', 'mock']
 setup(
   name = "karateclub",
   packages = find_packages(),
-  version = "1.0.11",
+  version = "1.0.12",
   license = "GPLv3",
   description = "A general purpose library for community detection, network embedding, and graph mining research.",
   author = "Benedek Rozemberczki",


### PR DESCRIPTION
`os.path.join` doesn't work on Windows for http urls (since seperator is not /).
Using an f-string to allow the classes to be called on any platform.