### PR TITLE
docs: Fix simple typo, occurences -> occurrences

### DIFF
--- a/karateclub/graph_embedding/gl2vec.py
+++ b/karateclub/graph_embedding/gl2vec.py
@@ -24,7 +24,7 @@ class GL2Vec(Estimator):
         down_sampling (float): Down sampling frequency. Default is 0.0001.
         epochs (int): Number of epochs. Default is 10.
         learning_rate (float): HogWild! learning rate. Default is 0.025.
-        min_count (int): Minimal count of graph feature occurences. Default is 5.
+        min_count (int): Minimal count of graph feature occurrences. Default is 5.
         seed (int): Random seed for the model. Default is 42.
     """
     def __init__(self, wl_iterations: int=2, dimensions: int=128, workers: int=4,

--- a/karateclub/graph_embedding/graph2vec.py
+++ b/karateclub/graph_embedding/graph2vec.py
@@ -24,7 +24,7 @@ class Graph2Vec(Estimator):
         down_sampling (float): Down sampling frequency. Default is 0.0001.
         epochs (int): Number of epochs. Default is 10.
         learning_rate (float): HogWild! learning rate. Default is 0.025.
-        min_count (int): Minimal count of graph feature occurences. Default is 5.
+        min_count (int): Minimal count of graph feature occurrences. Default is 5.
         seed (int): Random seed for the model. Default is 42.
         erase_base_features (bool): Erasing the base features. Default is False.
     """

--- a/karateclub/node_embedding/attributed/musae.py
+++ b/karateclub/node_embedding/attributed/musae.py
@@ -25,7 +25,7 @@ class MUSAE(Estimator):
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         down_sampling (float): Down sampling rate in the corpus. Default is 0.0001.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, walk_number=5, walk_length=80, dimensions=32, workers=4,

--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -22,7 +22,7 @@ class SINE(Estimator):
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, walk_number: int=10, walk_length: int=80, dimensions: int=128,

--- a/karateclub/node_embedding/neighbourhood/deepwalk.py
+++ b/karateclub/node_embedding/neighbourhood/deepwalk.py
@@ -19,7 +19,7 @@ class DeepWalk(Estimator):
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, walk_number: int=10, walk_length: int=80, dimensions: int=128,

--- a/karateclub/node_embedding/neighbourhood/diff2vec.py
+++ b/karateclub/node_embedding/neighbourhood/diff2vec.py
@@ -19,7 +19,7 @@ class Diff2Vec(Estimator):
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, diffusion_number: int=10, diffusion_cover: int=80,

--- a/karateclub/node_embedding/neighbourhood/node2vec.py
+++ b/karateclub/node_embedding/neighbourhood/node2vec.py
@@ -21,7 +21,7 @@ class Node2Vec(Estimator):
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, walk_number: int=10, walk_length: int=80, p: float=1.0, q: float=1.0,

--- a/karateclub/node_embedding/neighbourhood/walklets.py
+++ b/karateclub/node_embedding/neighbourhood/walklets.py
@@ -20,7 +20,7 @@ class Walklets(Estimator):
         window_size (int): Matrix power order. Default is 4.
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
-        min_count (int): Minimal count of node occurences. Default is 1.
+        min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
     """
     def __init__(self, walk_number: int=10, walk_length: int=80, dimensions: int=32,

--- a/karateclub/node_embedding/structural/role2vec.py
+++ b/karateclub/node_embedding/structural/role2vec.py
@@ -22,7 +22,7 @@ class Role2Vec(Estimator):
         epochs (int): Number of epochs. Default is 1.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         down_sampling (float): Down sampling frequency. Default is 0.0001.
-        min_count (int): Minimal count of feature occurences. Default is 10.
+        min_count (int): Minimal count of feature occurrences. Default is 10.
         wl_iterations (int): Number of Weisfeiler-Lehman hashing iterations. Default is 2.
         seed (int): Random seed value. Default is 42.
         erase_base_features (bool): Removing the base features. Default is False.


### PR DESCRIPTION
There is a small typo in karateclub/graph_embedding/gl2vec.py, karateclub/graph_embedding/graph2vec.py, karateclub/node_embedding/attributed/musae.py, karateclub/node_embedding/attributed/sine.py, karateclub/node_embedding/neighbourhood/deepwalk.py, karateclub/node_embedding/neighbourhood/diff2vec.py, karateclub/node_embedding/neighbourhood/node2vec.py, karateclub/node_embedding/neighbourhood/walklets.py, karateclub/node_embedding/structural/role2vec.py.

Should read `occurrences` rather than `occurences`.

