### PR TITLE
Exposed parameter `maximum_number_of_iterations`

### DIFF
--- a/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
+++ b/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
@@ -12,12 +12,18 @@ class LaplacianEigenmaps(Estimator):
 
     Args:
         dimensions (int): Dimensionality of embedding. Default is 128.
+        maximum_number_of_iterations (int): Maximum number of iterations to execute with ARPACK. The value will be multiplied by the number of nodes.
         seed (int): Random seed value. Default is 42.
     """
 
-    def __init__(self, dimensions: int = 128, seed: int = 42):
-
+    def __init__(
+        self,
+        dimensions: int = 128,
+        maximum_number_of_iterations: int = 100,
+        seed: int = 42
+    ):
         self.dimensions = dimensions
+        self.maximum_number_of_iterations = maximum_number_of_iterations
         self.seed = seed
 
     def fit(self, graph: nx.classes.graph.Graph):
@@ -32,7 +38,11 @@ class LaplacianEigenmaps(Estimator):
         number_of_nodes = graph.number_of_nodes()
         L_tilde = nx.normalized_laplacian_matrix(graph, nodelist=range(number_of_nodes))
         _, self._embedding = sps.linalg.eigsh(
-            L_tilde, k=self.dimensions, which="SM", return_eigenvectors=True
+            L_tilde,
+            k=self.dimensions,
+            which="SM",
+            maxiter=self.maximum_number_of_iterations,
+            return_eigenvectors=True
         )
 
     def get_embedding(self) -> np.array:

--- a/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
+++ b/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
@@ -41,7 +41,7 @@ class LaplacianEigenmaps(Estimator):
             L_tilde,
             k=self.dimensions,
             which="SM",
-            maxiter=self.maximum_number_of_iterations,
+            maxiter=self.maximum_number_of_iterations * number_of_nodes,
             return_eigenvectors=True
         )
 


### PR DESCRIPTION
On some inputs, methods based on ARPACK may fail because of missed convergence. The default value on scipy is a bit too strict (`maxiter = 10*number_of_nodes`), so I have exposed the parameter and set it as default to (`maxiter = 100*number_of_nodes`).

So far, I have encountered convergence issues only in this model, as computing the smallest eigenvectors can be more complicated than the largest ones. If I encounter this issue in other models, I will also make a pull request.