### PR TITLE
Pyre type error fixed.

### DIFF
--- a/karateclub/community_detection/overlapping/bigclam.py
+++ b/karateclub/community_detection/overlapping/bigclam.py
@@ -23,7 +23,7 @@ class BigClam(Estimator):
         self,
         dimensions: int = 8,
         iterations: int = 50,
-        learning_rate: int = 0.005,
+        learning_rate: float = 0.005,
         seed: int = 42,
     ):
         self.dimensions = dimensions


### PR DESCRIPTION
**"filename"**: "karateclub/community_detection/overlapping/bigclam.py"
**"warning_type"**: "Incompatible variable type [9]"
**"warning_message"**: " learning_rate is declared to have type `int` but is used as type `float`."
**"warning_line"**: 26
**"fix"**: int to float