### PR TITLE
Replaced fullargsspec with signature, as it broke in my system

### DIFF
--- a/karateclub/node_embedding/neighbourhood/boostne.py
+++ b/karateclub/node_embedding/neighbourhood/boostne.py
@@ -3,7 +3,7 @@ import networkx as nx
 from scipy import sparse
 from sklearn.decomposition import NMF
 from karateclub.estimator import Estimator
-from inspect import getfullargspec
+from inspect import signature
 
 
 class BoostNE(Estimator):
@@ -128,7 +128,7 @@ class BoostNE(Estimator):
             * **W** *(Numpy array)* - The embedding matrix.
         """
         
-        parameter_names = getfullargspec(NMF).args
+        parameter_names = signature(NMF).parameters
 
         if "alpha" in parameter_names:
             model = NMF(


### PR DESCRIPTION
Hello, I did a 🍌.

While generally `fullargsspec` works better than `signature`, since the latter can break when dealing with things such as code bindings, I discovered the hard way that the former breaks in some cases, like our friend `NMF`, and return an empty list of args and kwargs.

I have no clue why it does break.

Notwithstanding, I replaced it with `signature`, which seems more stable in these use cases.