### PR TITLE
Update requirements to modern versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "numpy<1.23.0",
-    "networkx<2.7",
-    "decorator==4.4.2",
+    "numpy==1.23.*",
+    "networkx==2.8.*",
+    "decorator==5.1.*",
+    "pandas==1.5.*",
+    "gensim>=4.0.0",
     "tqdm",
     "python-louvain",
     "scikit-learn",
     "scipy",
     "pygsp",
-    "gensim>=4.0.0",
-    "pandas<=1.3.5",
     "six",
     "python-Levenshtein"
 ]


### PR DESCRIPTION
With the many deprecation warnings, there is a need to limit the user to certain versions. The wildcard syntax on the trailing version number will allow for bug fixes in those packages without allowing the user to install package versions that break things.

A separate issue is needed to tackle the `DeprecationWarning` warnings coming from the responsible packages.

I shifted the packages requiring specific versions to the top of the list.

Passing local tests run with `pytest`.

Fix issue #117.