### PR TITLE
Exposed and documented `negative` parameter for Word2Vec-based models

### DIFF
--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -22,6 +22,7 @@ class SINE(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        use_hierarchical_softmax (bool): Whether to use hierarchical softmax or negative sampling to train the model.
         number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
@@ -36,6 +37,7 @@ class SINE(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        use_hierarchical_softmax: bool = True,
         number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
@@ -48,6 +50,7 @@ class SINE(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.use_hierarchical_softmax = use_hierarchical_softmax
         self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count

--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -22,6 +22,7 @@ class SINE(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
@@ -35,6 +36,7 @@ class SINE(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
@@ -46,6 +48,7 @@ class SINE(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
         self.seed = seed
@@ -91,6 +94,7 @@ class SINE(Estimator):
         model = Word2Vec(
             self._walklets,
             hs=0,
+            negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             vector_size=self.dimensions,
             window=1,

--- a/karateclub/node_embedding/neighbourhood/deepwalk.py
+++ b/karateclub/node_embedding/neighbourhood/deepwalk.py
@@ -19,6 +19,7 @@ class DeepWalk(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        use_hierarchical_softmax (bool): Whether to use hierarchical softmax or negative sampling to train the model. Default is True.
         number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
@@ -33,18 +34,19 @@ class DeepWalk(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        use_hierarchical_softmax: bool = True,
         number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
     ):
-
         self.walk_number = walk_number
         self.walk_length = walk_length
         self.dimensions = dimensions
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.use_hierarchical_softmax = use_hierarchical_softmax
         self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
@@ -64,7 +66,7 @@ class DeepWalk(Estimator):
 
         model = Word2Vec(
             walker.walks,
-            hs=1,
+            hs=1 if self.use_hierarchical_softmax else 0,
             negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,

--- a/karateclub/node_embedding/neighbourhood/deepwalk.py
+++ b/karateclub/node_embedding/neighbourhood/deepwalk.py
@@ -19,6 +19,7 @@ class DeepWalk(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
@@ -32,6 +33,7 @@ class DeepWalk(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
@@ -43,6 +45,7 @@ class DeepWalk(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
         self.seed = seed
@@ -62,6 +65,7 @@ class DeepWalk(Estimator):
         model = Word2Vec(
             walker.walks,
             hs=1,
+            negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,
             vector_size=self.dimensions,

--- a/karateclub/node_embedding/neighbourhood/diff2vec.py
+++ b/karateclub/node_embedding/neighbourhood/diff2vec.py
@@ -19,6 +19,7 @@ class Diff2Vec(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
@@ -32,6 +33,7 @@ class Diff2Vec(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
@@ -43,6 +45,7 @@ class Diff2Vec(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
         self.seed = seed
@@ -62,6 +65,7 @@ class Diff2Vec(Estimator):
         model = Word2Vec(
             diffuser.diffusions,
             hs=1,
+            negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,
             vector_size=self.dimensions,

--- a/karateclub/node_embedding/neighbourhood/diff2vec.py
+++ b/karateclub/node_embedding/neighbourhood/diff2vec.py
@@ -19,6 +19,7 @@ class Diff2Vec(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        use_hierarchical_softmax (bool): Whether to use hierarchical softmax or negative sampling to train the model. Default is True.
         number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
@@ -33,6 +34,7 @@ class Diff2Vec(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        use_hierarchical_softmax: bool = True,
         number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
@@ -45,6 +47,7 @@ class Diff2Vec(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.use_hierarchical_softmax = use_hierarchical_softmax
         self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
@@ -64,7 +67,7 @@ class Diff2Vec(Estimator):
 
         model = Word2Vec(
             diffuser.diffusions,
-            hs=1,
+            hs=1 if self.use_hierarchical_softmax else 0,
             negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,

--- a/karateclub/node_embedding/neighbourhood/node2vec.py
+++ b/karateclub/node_embedding/neighbourhood/node2vec.py
@@ -24,6 +24,7 @@ class Node2Vec(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
@@ -40,6 +41,7 @@ class Node2Vec(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
@@ -54,6 +56,7 @@ class Node2Vec(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
         self.seed = seed
@@ -73,6 +76,7 @@ class Node2Vec(Estimator):
         model = Word2Vec(
             walker.walks,
             hs=1,
+            negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,
             vector_size=self.dimensions,

--- a/karateclub/node_embedding/neighbourhood/node2vec.py
+++ b/karateclub/node_embedding/neighbourhood/node2vec.py
@@ -24,6 +24,7 @@ class Node2Vec(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 5.
         epochs (int): Number of epochs. Default is 1.
+        use_hierarchical_softmax (bool): Whether to use hierarchical softmax or negative sampling to train the model. Default is True.
         number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
@@ -41,6 +42,7 @@ class Node2Vec(Estimator):
         workers: int = 4,
         window_size: int = 5,
         epochs: int = 1,
+        use_hierarchical_softmax: bool = True,
         number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
@@ -56,6 +58,7 @@ class Node2Vec(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.use_hierarchical_softmax = use_hierarchical_softmax
         self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
@@ -75,7 +78,7 @@ class Node2Vec(Estimator):
 
         model = Word2Vec(
             walker.walks,
-            hs=1,
+            hs=1 if self.use_hierarchical_softmax else 0,
             negative=self.number_of_negative_samples,
             alpha=self.learning_rate,
             epochs=self.epochs,

--- a/karateclub/node_embedding/neighbourhood/walklets.py
+++ b/karateclub/node_embedding/neighbourhood/walklets.py
@@ -20,6 +20,7 @@ class Walklets(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 4.
         epochs (int): Number of epochs. Default is 1.
+        number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
         seed (int): Random seed value. Default is 42.
@@ -33,6 +34,7 @@ class Walklets(Estimator):
         workers: int = 4,
         window_size: int = 4,
         epochs: int = 1,
+        number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
         seed: int = 42,
@@ -44,6 +46,7 @@ class Walklets(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
         self.seed = seed
@@ -75,6 +78,7 @@ class Walklets(Estimator):
             model = Word2Vec(
                 walklets,
                 hs=0,
+                negative=self.number_of_negative_samples,
                 alpha=self.learning_rate,
                 epochs=self.epochs,
                 vector_size=self.dimensions,

--- a/karateclub/node_embedding/neighbourhood/walklets.py
+++ b/karateclub/node_embedding/neighbourhood/walklets.py
@@ -20,6 +20,7 @@ class Walklets(Estimator):
         workers (int): Number of cores. Default is 4.
         window_size (int): Matrix power order. Default is 4.
         epochs (int): Number of epochs. Default is 1.
+        use_hierarchical_softmax (bool): Whether to use hierarchical softmax or negative sampling to train the model. Default is False.
         number_of_negative_samples (int): Number of negative nodes to sample (usually between 5-20). If set to 0, no negative sampling is used. Default is 5.
         learning_rate (float): HogWild! learning rate. Default is 0.05.
         min_count (int): Minimal count of node occurrences. Default is 1.
@@ -34,6 +35,7 @@ class Walklets(Estimator):
         workers: int = 4,
         window_size: int = 4,
         epochs: int = 1,
+        use_hierarchical_softmax: bool = True,
         number_of_negative_samples: int = 5,
         learning_rate: float = 0.05,
         min_count: int = 1,
@@ -46,6 +48,7 @@ class Walklets(Estimator):
         self.workers = workers
         self.window_size = window_size
         self.epochs = epochs
+        self.use_hierarchical_softmax = use_hierarchical_softmax
         self.number_of_negative_samples = number_of_negative_samples
         self.learning_rate = learning_rate
         self.min_count = min_count
@@ -77,7 +80,7 @@ class Walklets(Estimator):
             walklets = self._select_walklets(walker.walks, power)
             model = Word2Vec(
                 walklets,
-                hs=0,
+                hs=1 if self.use_hierarchical_softmax else 0,
                 negative=self.number_of_negative_samples,
                 alpha=self.learning_rate,
                 epochs=self.epochs,


### PR DESCRIPTION
Hi!

I exposed the `negative` parameter from the GenSim implementation of Word2Vec, which defines the number of negative nodes sampled.

I have called the parameter `number_of_negative_samples` and set it to GenSim's default value which is 5.

Best,
Luca