### PR TITLE
Relax dependency requirements

### DIFF
--- a/karateclub/graph_embedding/gl2vec.py
+++ b/karateclub/graph_embedding/gl2vec.py
@@ -101,7 +101,7 @@ class GL2Vec(Estimator):
             seed=self.seed,
         )
 
-        self._embedding = [self.model.docvecs[str(i)] for i, _ in enumerate(documents)]
+        self._embedding = [self.model.dv[str(i)] for i, _ in enumerate(documents)]
 
     def get_embedding(self) -> np.array:
         r"""Getting the embedding of graphs.

--- a/karateclub/graph_embedding/graph2vec.py
+++ b/karateclub/graph_embedding/graph2vec.py
@@ -88,7 +88,7 @@ class Graph2Vec(Estimator):
             seed=self.seed,
         )
 
-        self._embedding = [self.model.docvecs[str(i)] for i, _ in enumerate(documents)]
+        self._embedding = [self.model.dv[str(i)] for i, _ in enumerate(documents)]
 
     def get_embedding(self) -> np.array:
         r"""Getting the embedding of graphs.

--- a/karateclub/node_embedding/attributed/ae.py
+++ b/karateclub/node_embedding/attributed/ae.py
@@ -75,7 +75,7 @@ class AE(Estimator):
         )
 
         emb = np.array(
-            [model.docvecs[str(n)] for n in range(self.graph.number_of_nodes())]
+            [model.dv[str(n)] for n in range(self.graph.number_of_nodes())]
         )
         return emb
 

--- a/karateclub/node_embedding/attributed/asne.py
+++ b/karateclub/node_embedding/attributed/asne.py
@@ -80,7 +80,7 @@ class ASNE(Estimator):
         )
 
         self._embedding = np.array(
-            [model.docvecs[str(i)] for i, _ in enumerate(documents)]
+            [model.dv[str(i)] for i, _ in enumerate(documents)]
         )
 
     def get_embedding(self) -> np.array:

--- a/karateclub/node_embedding/attributed/musae.py
+++ b/karateclub/node_embedding/attributed/musae.py
@@ -77,7 +77,7 @@ class MUSAE(Estimator):
         )
 
         emb = np.array(
-            [model.docvecs[str(n)] for n in range(self.graph.number_of_nodes())]
+            [model.dv[str(n)] for n in range(self.graph.number_of_nodes())]
         )
         return emb
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = [
     "numpy==1.23.*",
     "networkx==2.8.*",
     "decorator==5.1.*",
-    "pandas==1.5.*",
+    "pandas>=1.2.0",
     "gensim>=4.0.0",
     "tqdm",
     "python-louvain",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "numpy==1.23.*",
+    "numpy>=1.22.0",
     "networkx==2.8.*",
     "decorator==5.1.*",
     "pandas>=1.2.0",


### PR DESCRIPTION
- Tested a few versions of `pandas`, to include 1.2.0 and 2.0.0rc0 and rc1 with the current requirements without issue.
- Tested a few versions of `numpy`. Found that the latest version (1.24.2) passes the test cases, as does 1.22.0. Set the value for anything higher than 1.22.0 as a result.
- Change `.docvec` to `.dv` to satisfy deprecation warning.

Relate #133 