### PR TITLE
Now we clone the graph before adding the main diagonal, with a proper warning

### DIFF
--- a/karateclub/node_embedding/neighbourhood/first_order_line.py
+++ b/karateclub/node_embedding/neighbourhood/first_order_line.py
@@ -68,7 +68,7 @@ class FirstOrderLINE(Estimator):
 
         self.embedding = np.random.uniform(size=(number_of_nodes, self.dimensions))
 
-        for epoch in trange(self.epochs, desc="Epochs", disable=not self.verbose):
+        for epoch in trange(self.epochs, desc="Epochs", disable=not self.verbose, leave=False):
             for _ in range(number_of_edges // self.mini_batch_size):
                 gradient = np.zeros_like(self.embedding)
 

--- a/karateclub/node_embedding/neighbourhood/second_order_line.py
+++ b/karateclub/node_embedding/neighbourhood/second_order_line.py
@@ -72,7 +72,7 @@ class SecondOrderLINE(Estimator):
         self.src_embedding = np.random.uniform(size=(number_of_nodes, self.dimensions // 2))
         self.dst_embedding = np.random.uniform(size=(number_of_nodes, self.dimensions // 2))
 
-        for epoch in trange(self.epochs, desc="Epochs", disable=not self.verbose):
+        for epoch in trange(self.epochs, desc="Epochs", disable=not self.verbose, leave=False):
             for _ in range(number_of_edges // self.mini_batch_size):
                 src_gradient = np.zeros_like(self.src_embedding)
                 dst_gradient = np.zeros_like(self.dst_embedding)


### PR DESCRIPTION
Addressing issue #136 by cloning the graph when its adjacency matrix does not contain the main diagonal. When that is necessary, a verbose warning is shown to make it clear to the user that the graph is being allocated twice.

Possibly I should only raise the warning if the graph has more than, let's say, 10k nodes? I expect the graph sizes usually employed with this python implementation to be manageable, but one never knows what a user may want to do.