### PR TITLE
Fit transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode project settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode project settings
+.vscode/
+
+# Mac OS X clutter
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VSCode project settings
 .vscode/
+
+# Mac OS X clutter
+**/.DS_Store

--- a/karateclub/estimator.py
+++ b/karateclub/estimator.py
@@ -33,13 +33,19 @@ class Estimator(object):
     def get_cluster_centers(self):
         """Getting the cluster centers."""
         pass
-    
+
     def get_params(self):
         """Get parameter dictionary for this estimator.."""
         rx = re.compile(r'^\_')
         params = self.__dict__
         params = {key: params[key] for key in params if not rx.search(key)}
         return params
+
+    def set_params(self, **parameters):
+        """Set the parameters of this estimator."""
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self
 
     def _set_seed(self):
         """Creating the initial random seed."""

--- a/karateclub/estimator.py
+++ b/karateclub/estimator.py
@@ -26,14 +26,22 @@ class Estimator(object):
         """Getting the embeddings (graph or node level)."""
         pass
 
+    def fit_transform(self):
+        """Fitting a model and getting the embeddings."""
+        pass
+
     def get_memberships(self):
         """Getting the membership dictionary."""
+        pass
+
+    def fit_predict(self):
+        """Fitting a model and getting the membership."""
         pass
 
     def get_cluster_centers(self):
         """Getting the cluster centers."""
         pass
-    
+
     def get_params(self):
         """Get parameter dictionary for this estimator.."""
         rx = re.compile(r'^\_')

--- a/karateclub/estimator.py
+++ b/karateclub/estimator.py
@@ -42,7 +42,8 @@ class Estimator(object):
         """Getting the cluster centers."""
         pass
 
-    def get_params(self):
+    def get_params(self, deep=True):
+        # Ignore deep=False, since we don't have nested estimators
         """Get parameter dictionary for this estimator.."""
         rx = re.compile(r'^\_')
         params = self.__dict__

--- a/karateclub/node_embedding/attributed/ae.py
+++ b/karateclub/node_embedding/attributed/ae.py
@@ -141,3 +141,23 @@ class AE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.concatenate(self._embeddings, axis=1)
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/ae.py
+++ b/karateclub/node_embedding/attributed/ae.py
@@ -141,19 +141,3 @@ class AE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.concatenate(self._embeddings, axis=1)
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/ae.py
+++ b/karateclub/node_embedding/attributed/ae.py
@@ -141,3 +141,19 @@ class AE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.concatenate(self._embeddings, axis=1)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/asne.py
+++ b/karateclub/node_embedding/attributed/asne.py
@@ -91,3 +91,23 @@ class ASNE(Estimator):
         """
         embedding = self._embedding
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/asne.py
+++ b/karateclub/node_embedding/attributed/asne.py
@@ -91,3 +91,19 @@ class ASNE(Estimator):
         """
         embedding = self._embedding
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/asne.py
+++ b/karateclub/node_embedding/attributed/asne.py
@@ -91,19 +91,3 @@ class ASNE(Estimator):
         """
         embedding = self._embedding
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/asne.py
+++ b/karateclub/node_embedding/attributed/asne.py
@@ -1,6 +1,7 @@
 import random
 import numpy as np
 import networkx as nx
+from typing import Union
 from scipy.sparse import coo_matrix
 from karateclub.estimator import Estimator
 from gensim.models.doc2vec import Doc2Vec, TaggedDocument

--- a/karateclub/node_embedding/attributed/bane.py
+++ b/karateclub/node_embedding/attributed/bane.py
@@ -136,3 +136,23 @@ class BANE(Estimator):
         """
         embedding = self._B
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/bane.py
+++ b/karateclub/node_embedding/attributed/bane.py
@@ -136,19 +136,3 @@ class BANE(Estimator):
         """
         embedding = self._B
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/bane.py
+++ b/karateclub/node_embedding/attributed/bane.py
@@ -136,3 +136,19 @@ class BANE(Estimator):
         """
         embedding = self._B
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/feathernode.py
+++ b/karateclub/node_embedding/attributed/feathernode.py
@@ -138,19 +138,3 @@ class FeatherNode(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._feature_blocks
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/feathernode.py
+++ b/karateclub/node_embedding/attributed/feathernode.py
@@ -138,3 +138,23 @@ class FeatherNode(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._feature_blocks
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/feathernode.py
+++ b/karateclub/node_embedding/attributed/feathernode.py
@@ -138,3 +138,19 @@ class FeatherNode(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._feature_blocks
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/fscnmf.py
+++ b/karateclub/node_embedding/attributed/fscnmf.py
@@ -162,3 +162,23 @@ class FSCNMF(Estimator):
         """
         embedding = np.concatenate([self._B_1, self._U], axis=1)
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/fscnmf.py
+++ b/karateclub/node_embedding/attributed/fscnmf.py
@@ -162,19 +162,3 @@ class FSCNMF(Estimator):
         """
         embedding = np.concatenate([self._B_1, self._U], axis=1)
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/fscnmf.py
+++ b/karateclub/node_embedding/attributed/fscnmf.py
@@ -162,3 +162,19 @@ class FSCNMF(Estimator):
         """
         embedding = np.concatenate([self._B_1, self._U], axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/musae.py
+++ b/karateclub/node_embedding/attributed/musae.py
@@ -145,3 +145,19 @@ class MUSAE(Estimator):
         """
         embedding = np.concatenate(self.embeddings, axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/musae.py
+++ b/karateclub/node_embedding/attributed/musae.py
@@ -145,3 +145,23 @@ class MUSAE(Estimator):
         """
         embedding = np.concatenate(self.embeddings, axis=1)
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/musae.py
+++ b/karateclub/node_embedding/attributed/musae.py
@@ -145,19 +145,3 @@ class MUSAE(Estimator):
         """
         embedding = np.concatenate(self.embeddings, axis=1)
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -119,19 +119,3 @@ class SINE(Estimator):
         """
         embedding = self.embedding
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -119,3 +119,23 @@ class SINE(Estimator):
         """
         embedding = self.embedding
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/sine.py
+++ b/karateclub/node_embedding/attributed/sine.py
@@ -119,3 +119,19 @@ class SINE(Estimator):
         """
         embedding = self.embedding
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tadw.py
+++ b/karateclub/node_embedding/attributed/tadw.py
@@ -156,19 +156,3 @@ class TADW(Estimator):
             [np.transpose(self._W), np.transpose(np.dot(self._H, self._T))], axis=1
         )
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tadw.py
+++ b/karateclub/node_embedding/attributed/tadw.py
@@ -156,3 +156,19 @@ class TADW(Estimator):
             [np.transpose(self._W), np.transpose(np.dot(self._H, self._T))], axis=1
         )
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tadw.py
+++ b/karateclub/node_embedding/attributed/tadw.py
@@ -156,3 +156,23 @@ class TADW(Estimator):
             [np.transpose(self._W), np.transpose(np.dot(self._H, self._T))], axis=1
         )
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tene.py
+++ b/karateclub/node_embedding/attributed/tene.py
@@ -152,3 +152,19 @@ class TENE(Estimator):
         """
         embedding = np.concatenate([self._M, self._Q], axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tene.py
+++ b/karateclub/node_embedding/attributed/tene.py
@@ -155,7 +155,7 @@ class TENE(Estimator):
 
     def fit_transform(self,
                       graph: nx.classes.graph.Graph,
-                      X: Union[np.array, coo_matrix],
+                      T: Union[np.array, coo_matrix],
                       y=None) -> np.array:
         r"""Fits model to input graph and returns embeddings.
 
@@ -167,7 +167,7 @@ class TENE(Estimator):
         Return types:
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
-        self.fit(graph, X)
+        self.fit(graph, T)
         if y is None:
             return self.get_embedding()
         else:

--- a/karateclub/node_embedding/attributed/tene.py
+++ b/karateclub/node_embedding/attributed/tene.py
@@ -152,19 +152,3 @@ class TENE(Estimator):
         """
         embedding = np.concatenate([self._M, self._Q], axis=1)
         return embedding
-
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
-        r"""Fits model to input graph and returns embeddings.
-
-        Arg types:
-            * **graph** *(NetworkX graph)* - The graph to be embedded.
-            * **y** *(None)* - Not used. For consistency with scikit-learn API.
-
-        Return types:
-            * **embedding** *(Numpy array)* - The embedding of nodes.
-        """
-        self.fit(graph)
-        if y is None:
-            return self.get_embedding()
-        else:
-            return self.get_embedding(), y

--- a/karateclub/node_embedding/attributed/tene.py
+++ b/karateclub/node_embedding/attributed/tene.py
@@ -152,3 +152,23 @@ class TENE(Estimator):
         """
         embedding = np.concatenate([self._M, self._Q], axis=1)
         return embedding
+
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      X: Union[np.array, coo_matrix],
+                      y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **X** *(Scipy COO array)* - The binary matrix of node features.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph, X)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/meta/neu.py
+++ b/karateclub/node_embedding/meta/neu.py
@@ -77,3 +77,19 @@ class NEU(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/meta/neu.py
+++ b/karateclub/node_embedding/meta/neu.py
@@ -78,17 +78,21 @@ class NEU(Estimator):
         """
         return self._embedding
 
-    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+    def fit_transform(self,
+                      graph: nx.classes.graph.Graph,
+                      model: Estimator,
+                      y=None) -> np.array:
         r"""Fits model to input graph and returns embeddings.
 
         Arg types:
             * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **model** *(KC embedding model)* - Karate Club embedding.
             * **y** *(None)* - Not used. For consistency with scikit-learn API.
 
         Return types:
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
-        self.fit(graph)
+        self.fit(graph, model)
         if y is None:
             return self._embedding
         else:

--- a/karateclub/node_embedding/neighbourhood/boostne.py
+++ b/karateclub/node_embedding/neighbourhood/boostne.py
@@ -240,3 +240,19 @@ class BoostNE(Estimator):
         """
         embedding = np.concatenate(self._embeddings, axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/deepwalk.py
+++ b/karateclub/node_embedding/neighbourhood/deepwalk.py
@@ -100,6 +100,6 @@ class DeepWalk(Estimator):
         """
         self.fit(graph)
         if y is None:
-            return self._embedding
+            return self.get_embedding()
         else:
-            return self._embedding, y
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/deepwalk.py
+++ b/karateclub/node_embedding/neighbourhood/deepwalk.py
@@ -87,3 +87,19 @@ class DeepWalk(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.array(self._embedding)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/diff2vec.py
+++ b/karateclub/node_embedding/neighbourhood/diff2vec.py
@@ -88,3 +88,19 @@ class Diff2Vec(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.array(self._embedding)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/diff2vec.py
+++ b/karateclub/node_embedding/neighbourhood/diff2vec.py
@@ -101,6 +101,6 @@ class Diff2Vec(Estimator):
         """
         self.fit(graph)
         if y is None:
-            return self._embedding
+            return self.get_embedding()
         else:
-            return self._embedding, y
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/first_order_line.py
+++ b/karateclub/node_embedding/neighbourhood/first_order_line.py
@@ -96,3 +96,19 @@ class FirstOrderLINE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self.embedding
+    
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/first_order_line.py
+++ b/karateclub/node_embedding/neighbourhood/first_order_line.py
@@ -96,7 +96,7 @@ class FirstOrderLINE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self.embedding
-    
+
     def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
         r"""Fits model to input graph and returns embeddings.
 
@@ -109,6 +109,6 @@ class FirstOrderLINE(Estimator):
         """
         self.fit(graph)
         if y is None:
-            return self._embedding
+            return self.embedding
         else:
-            return self._embedding, y
+            return self.embedding, y

--- a/karateclub/node_embedding/neighbourhood/geometriclaplacianeigenmaps.py
+++ b/karateclub/node_embedding/neighbourhood/geometriclaplacianeigenmaps.py
@@ -42,3 +42,19 @@ class GLEE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/grarep.py
+++ b/karateclub/node_embedding/neighbourhood/grarep.py
@@ -112,3 +112,19 @@ class GraRep(Estimator):
         """
         embedding = np.concatenate(self._embeddings, axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/hope.py
+++ b/karateclub/node_embedding/neighbourhood/hope.py
@@ -57,3 +57,19 @@ class HOPE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.concatenate([self._left_embedding, self._right_embedding], axis=1)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        """Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
+++ b/karateclub/node_embedding/neighbourhood/laplacianeigenmaps.py
@@ -52,3 +52,19 @@ class LaplacianEigenmaps(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/netmf.py
+++ b/karateclub/node_embedding/neighbourhood/netmf.py
@@ -104,7 +104,7 @@ class NetMF(Estimator):
         embedding = svd.transform(target_matrix)
         return embedding
 
-    def fit(self, graph: nx.classes.graph.Graph):
+    def fit(self, graph: nx.classes.graph.Graph, y=None):
         """
         Fitting a NetMF model.
 

--- a/karateclub/node_embedding/neighbourhood/netmf.py
+++ b/karateclub/node_embedding/neighbourhood/netmf.py
@@ -136,4 +136,7 @@ class NetMF(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         self.fit(graph)
-        return self._embedding
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/netmf.py
+++ b/karateclub/node_embedding/neighbourhood/netmf.py
@@ -123,3 +123,16 @@ class NetMF(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        return self._embedding

--- a/karateclub/node_embedding/neighbourhood/netmf.py
+++ b/karateclub/node_embedding/neighbourhood/netmf.py
@@ -110,6 +110,7 @@ class NetMF(Estimator):
 
         Arg types:
             * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
         """
         self._set_seed()
         graph = self._check_graph(graph)
@@ -117,7 +118,7 @@ class NetMF(Estimator):
         self._embedding = self._create_embedding(target_matrix)
 
     def get_embedding(self) -> np.array:
-        r"""Getting the node embedding.
+        """Getting the node embedding.
 
         Return types:
             * **embedding** *(Numpy array)* - The embedding of nodes.

--- a/karateclub/node_embedding/neighbourhood/nmfadmm.py
+++ b/karateclub/node_embedding/neighbourhood/nmfadmm.py
@@ -174,3 +174,19 @@ class NMFADMM(Estimator):
         """
         embedding = np.concatenate([self._W_plus, self._H_plus.T], axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/node2vec.py
+++ b/karateclub/node_embedding/neighbourhood/node2vec.py
@@ -112,6 +112,6 @@ class Node2Vec(Estimator):
         """
         self.fit(graph)
         if y is None:
-            return self._embedding
+            return self.get_embedding()
         else:
-            return self._embedding, y
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/node2vec.py
+++ b/karateclub/node_embedding/neighbourhood/node2vec.py
@@ -99,3 +99,19 @@ class Node2Vec(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.array(self._embedding)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/nodesketch.py
+++ b/karateclub/node_embedding/neighbourhood/nodesketch.py
@@ -121,3 +121,19 @@ class NodeSketch(Estimator):
         """
         embedding = np.transpose(self._sketch_to_np_array())
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/randne.py
+++ b/karateclub/node_embedding/neighbourhood/randne.py
@@ -89,3 +89,19 @@ class RandNE(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/second_order_line.py
+++ b/karateclub/node_embedding/neighbourhood/second_order_line.py
@@ -105,3 +105,19 @@ class SecondOrderLINE(Estimator):
             self.src_embedding,
             self.dst_embedding
         ])
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/sociodim.py
+++ b/karateclub/node_embedding/neighbourhood/sociodim.py
@@ -55,6 +55,6 @@ class SocioDim(Estimator):
         """
         self.fit(graph)
         if y is None:
-            return self._embedding
+            return self.get_embedding()
         else:
-            return self._embedding, y
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/neighbourhood/sociodim.py
+++ b/karateclub/node_embedding/neighbourhood/sociodim.py
@@ -42,3 +42,19 @@ class SocioDim(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return self._embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self._embedding
+        else:
+            return self._embedding, y

--- a/karateclub/node_embedding/neighbourhood/walklets.py
+++ b/karateclub/node_embedding/neighbourhood/walklets.py
@@ -101,3 +101,19 @@ class Walklets(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.concatenate(self._embedding, axis=1)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        r"""Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/structural/graphwave.py
+++ b/karateclub/node_embedding/structural/graphwave.py
@@ -158,3 +158,19 @@ class GraphWave(Estimator):
         embedding = [self._real_and_imaginary.real, self._real_and_imaginary.imag]
         embedding = np.concatenate(embedding, axis=1)
         return embedding
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        """Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/karateclub/node_embedding/structural/role2vec.py
+++ b/karateclub/node_embedding/structural/role2vec.py
@@ -158,3 +158,19 @@ class Role2Vec(Estimator):
             * **embedding** *(Numpy array)* - The embedding of nodes.
         """
         return np.array(self._embedding)
+
+    def fit_transform(self, graph: nx.classes.graph.Graph, y=None) -> np.array:
+        """Fits model to input graph and returns embeddings.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+            * **y** *(None)* - Not used. For consistency with scikit-learn API.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        self.fit(graph)
+        if y is None:
+            return self.get_embedding()
+        else:
+            return self.get_embedding(), y

--- a/test/attributed_node_embedding_test.py
+++ b/test/attributed_node_embedding_test.py
@@ -256,3 +256,4 @@ def test_ae():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * 2
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)

--- a/test/attributed_node_embedding_test.py
+++ b/test/attributed_node_embedding_test.py
@@ -217,7 +217,7 @@ def test_musae():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * (1 + model.window_size)
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph, features), embedding)
+    assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)
 
 
 def test_sine():
@@ -264,4 +264,4 @@ def test_ae():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * 2
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph, features), embedding)
+    assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)

--- a/test/attributed_node_embedding_test.py
+++ b/test/attributed_node_embedding_test.py
@@ -38,6 +38,11 @@ def test_asne():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_feather_node():
     """
@@ -86,6 +91,11 @@ def test_feather_node():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_bane():
     """
@@ -114,6 +124,11 @@ def test_bane():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_fscnmf():
     """
@@ -139,6 +154,11 @@ def test_fscnmf():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.dimensions
     assert np.array_equal(model.fit_transform(graph, features), embedding)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_tene():
@@ -168,6 +188,11 @@ def test_tene():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_tadw():
     """
@@ -196,6 +221,11 @@ def test_tadw():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_musae():
     """
@@ -218,6 +248,11 @@ def test_musae():
     assert embedding.shape[1] == model.dimensions * (1 + model.window_size)
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_sine():
@@ -243,6 +278,11 @@ def test_sine():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_ae():
     """
@@ -265,3 +305,8 @@ def test_ae():
     assert embedding.shape[1] == model.dimensions * 2
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, features, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)

--- a/test/attributed_node_embedding_test.py
+++ b/test/attributed_node_embedding_test.py
@@ -241,7 +241,7 @@ def test_sine():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph, features), embedding)
+    assert np.array_equal(model.fit_transform(graph, features).shape, embedding.shape)
 
 
 def test_ae():

--- a/test/attributed_node_embedding_test.py
+++ b/test/attributed_node_embedding_test.py
@@ -36,6 +36,7 @@ def test_asne():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_feather_node():
@@ -83,6 +84,7 @@ def test_feather_node():
         == 2 * model.order * model.eval_points * model.reduction_dimensions
     )
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_bane():
@@ -110,6 +112,7 @@ def test_bane():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_fscnmf():
@@ -135,6 +138,7 @@ def test_fscnmf():
 
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.dimensions
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_tene():
@@ -162,6 +166,7 @@ def test_tene():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_tadw():
@@ -189,6 +194,7 @@ def test_tadw():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_musae():
@@ -211,6 +217,7 @@ def test_musae():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * (1 + model.window_size)
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_sine():
@@ -234,6 +241,7 @@ def test_sine():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph, features), embedding)
 
 
 def test_ae():

--- a/test/meta_embedding_test.py
+++ b/test/meta_embedding_test.py
@@ -26,3 +26,4 @@ def test_neu():
 
     assert embedding.shape[0] == graph.number_of_nodes()
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)

--- a/test/meta_embedding_test.py
+++ b/test/meta_embedding_test.py
@@ -27,3 +27,8 @@ def test_neu():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)

--- a/test/meta_embedding_test.py
+++ b/test/meta_embedding_test.py
@@ -26,9 +26,10 @@ def test_neu():
 
     assert embedding.shape[0] == graph.number_of_nodes()
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+    assert np.array_equal(meta_model.fit_transform(graph, model).shape,
+                          embedding.shape)
 
     y = embedding[:, 0]
-    z, y_hat = model.fit_transform(graph, y)
+    z, y_hat = meta_model.fit_transform(graph, model, y)
     assert y_hat.shape[0] == graph.number_of_nodes()
     assert np.array_equal(y_hat, y)

--- a/test/neighbourhod_based_node_embedding_test.py
+++ b/test/neighbourhod_based_node_embedding_test.py
@@ -34,6 +34,7 @@ def test_randne():
     assert np.array_equal(model.fit_transform(graph), embedding)
 
 
+
 def test_sociodim():
     """
     Testing the SocioDim class.
@@ -61,7 +62,9 @@ def test_sociodim():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    # ? stochastic, therefore test shape not equality
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+
 
 
 def test_deepwalk():
@@ -91,7 +94,8 @@ def test_deepwalk():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    # ? stochastic, therefore test shape not equality
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 def test_first_order_line():
     """
@@ -179,7 +183,8 @@ def test_node2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    # ? stochastic, therefore test shape not equality
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_walklets():
@@ -209,7 +214,8 @@ def test_walklets():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * model.window_size
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    # ? stochastic, therefore test shape not equality
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_hope():
@@ -299,7 +305,7 @@ def test_diff2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_grarep():
@@ -389,7 +395,7 @@ def test_laplacianeigenmaps():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_geometriclaplacianeigenmaps():
@@ -419,7 +425,7 @@ def test_geometriclaplacianeigenmaps():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions + 1
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_nmf_admm():

--- a/test/neighbourhod_based_node_embedding_test.py
+++ b/test/neighbourhod_based_node_embedding_test.py
@@ -33,6 +33,10 @@ def test_randne():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_sociodim():
@@ -64,6 +68,10 @@ def test_sociodim():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_deepwalk():
@@ -95,6 +103,12 @@ def test_deepwalk():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
+
 def test_first_order_line():
     """
     Testing the First-order LINE class.
@@ -124,6 +138,12 @@ def test_first_order_line():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
+
 def test_second_order_line():
     """
     Testing the Second-order LINE class.
@@ -152,6 +172,11 @@ def test_second_order_line():
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_node2vec():
@@ -183,6 +208,11 @@ def test_node2vec():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_walklets():
     """
@@ -212,6 +242,11 @@ def test_walklets():
     assert embedding.shape[1] == model.dimensions * model.window_size
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_hope():
@@ -243,6 +278,11 @@ def test_hope():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_netmf():
     """
@@ -272,6 +312,11 @@ def test_netmf():
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_diff2vec():
@@ -303,6 +348,11 @@ def test_diff2vec():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_grarep():
     """
@@ -332,6 +382,11 @@ def test_grarep():
     assert embedding.shape[1] == model.dimensions * model.order
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_nodesketch():
@@ -363,6 +418,11 @@ def test_nodesketch():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_laplacianeigenmaps():
     """
@@ -392,6 +452,11 @@ def test_laplacianeigenmaps():
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
 
 
 def test_geometriclaplacianeigenmaps():
@@ -423,6 +488,11 @@ def test_geometriclaplacianeigenmaps():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_nmf_admm():
     """
@@ -452,3 +522,8 @@ def test_nmf_admm():
     assert embedding.shape[1] == model.dimensions * 2
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph), embedding)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)

--- a/test/neighbourhod_based_node_embedding_test.py
+++ b/test/neighbourhod_based_node_embedding_test.py
@@ -261,6 +261,7 @@ def test_netmf():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_diff2vec():

--- a/test/neighbourhod_based_node_embedding_test.py
+++ b/test/neighbourhod_based_node_embedding_test.py
@@ -31,6 +31,7 @@ def test_randne():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_sociodim():
@@ -60,6 +61,7 @@ def test_sociodim():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_deepwalk():
@@ -89,6 +91,7 @@ def test_deepwalk():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 def test_first_order_line():
     """
@@ -117,6 +120,7 @@ def test_first_order_line():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 def test_second_order_line():
     """
@@ -145,6 +149,7 @@ def test_second_order_line():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_node2vec():
@@ -174,6 +179,7 @@ def test_node2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_walklets():
@@ -203,6 +209,7 @@ def test_walklets():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * model.window_size
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_hope():
@@ -232,6 +239,7 @@ def test_hope():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_netmf():
@@ -291,6 +299,7 @@ def test_diff2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_grarep():
@@ -320,6 +329,7 @@ def test_grarep():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * model.order
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_nodesketch():
@@ -349,6 +359,7 @@ def test_nodesketch():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_laplacianeigenmaps():
@@ -378,6 +389,7 @@ def test_laplacianeigenmaps():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_geometriclaplacianeigenmaps():
@@ -407,6 +419,7 @@ def test_geometriclaplacianeigenmaps():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions + 1
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_nmf_admm():
@@ -436,3 +449,4 @@ def test_nmf_admm():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * 2
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)

--- a/test/neighbourhod_based_node_embedding_test.py
+++ b/test/neighbourhod_based_node_embedding_test.py
@@ -62,7 +62,6 @@ def test_sociodim():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    # ? stochastic, therefore test shape not equality
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
@@ -94,7 +93,6 @@ def test_deepwalk():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    # ? stochastic, therefore test shape not equality
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 def test_first_order_line():
@@ -183,7 +181,6 @@ def test_node2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    # ? stochastic, therefore test shape not equality
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
@@ -214,7 +211,6 @@ def test_walklets():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions * model.window_size
     assert type(embedding) == np.ndarray
-    # ? stochastic, therefore test shape not equality
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 

--- a/test/structral_node_embedding_test.py
+++ b/test/structral_node_embedding_test.py
@@ -30,6 +30,7 @@ def test_role2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph), embedding)
 
 
 def test_graphwave():
@@ -73,3 +74,4 @@ def test_graphwave():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.sample_number
     assert type(embedding) == np.ndarray
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)

--- a/test/structral_node_embedding_test.py
+++ b/test/structral_node_embedding_test.py
@@ -32,6 +32,11 @@ def test_role2vec():
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)
+
 
 def test_graphwave():
     """
@@ -75,3 +80,8 @@ def test_graphwave():
     assert embedding.shape[1] == 2 * model.sample_number
     assert type(embedding) == np.ndarray
     assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
+
+    y = embedding[:, 0]
+    z, y_hat = model.fit_transform(graph, y)
+    assert y_hat.shape[0] == graph.number_of_nodes()
+    assert np.array_equal(y_hat, y)

--- a/test/structral_node_embedding_test.py
+++ b/test/structral_node_embedding_test.py
@@ -30,7 +30,7 @@ def test_role2vec():
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == model.dimensions
     assert type(embedding) == np.ndarray
-    assert np.array_equal(model.fit_transform(graph), embedding)
+    assert np.array_equal(model.fit_transform(graph).shape, embedding.shape)
 
 
 def test_graphwave():

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -6,3 +6,14 @@ def test_get_params():
     assert len(params) != 0
     assert type(params) is dict
     assert '_embedding' not in params
+
+def test_set_params():
+    model = DeepWalk()
+    default_params = model.get_params()
+    params = {'dimensions': 1,
+              'seed': 123}
+    model.set_params(**params)
+    new_params = model.get_params()
+    assert new_params != default_params
+    assert new_params['dimensions'] == 1
+    assert new_params['seed'] == 123


### PR DESCRIPTION
Added `.fit_transform` method to all node embedding algorithms, primarily motivated by desire to use `karateclub` algorithms in a `scikit-learn` pipeline.

Adds:
* `y=None` argument, for scikit-learn compatibility
* Passthrough `if y is not None` to allow passing e.g. node attributes through for a downstream task in the pipeline

Tests:
* Method tested for each algorithm
* Generally testing that output matches that of `.get_embedding()`
* Unless stochastic method, when testing that shapes match