### PR TITLE
Add set_params to Estimator base class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode project settings
+.vscode/
+
+# Mac OS X clutter
+**/.DS_Store

--- a/karateclub/estimator.py
+++ b/karateclub/estimator.py
@@ -33,13 +33,19 @@ class Estimator(object):
     def get_cluster_centers(self):
         """Getting the cluster centers."""
         pass
-    
+
     def get_params(self):
         """Get parameter dictionary for this estimator.."""
         rx = re.compile(r'^\_')
         params = self.__dict__
         params = {key: params[key] for key in params if not rx.search(key)}
         return params
+
+    def set_params(self, **parameters):
+        """Set the parameters of this estimator."""
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self
 
     def _set_seed(self):
         """Creating the initial random seed."""

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -6,3 +6,14 @@ def test_get_params():
     assert len(params) != 0
     assert type(params) is dict
     assert '_embedding' not in params
+
+def test_set_params():
+    model = DeepWalk()
+    default_params = model.get_params()
+    params = {'dimensions': 1,
+              'seed': 123}
+    model.set_params(**params)
+    new_params = model.get_params()
+    assert new_params != default_params
+    assert new_params['dimensions'] == 1
+    assert new_params['seed'] == 123


### PR DESCRIPTION
Fixes #146 

Adding a sklearn-compatible set_params method to Estimator base class, useful for hyperparameter tuning.

Tested, coverage should be unchanged