### PR TITLE
Dependency Update

### DIFF
--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -52,10 +52,10 @@ class DANMF(Estimator):
         self._graph = graph
         self._A = nx.adjacency_matrix(
             self._graph, nodelist=range(self._graph.number_of_nodes())
-        )
+        ).todense()
         self._L = nx.laplacian_matrix(
             self._graph, nodelist=range(self._graph.number_of_nodes())
-        )
+        ).todense()
         self._D = self._L + self._A
 
     def _setup_z(self, i):
@@ -78,10 +78,11 @@ class DANMF(Estimator):
             * **i** *(int)* - The layer index.
         """
 
-        print("Pre-training layer {}.".format(i))
-        print("Random state: {}".format(self.seed))
-        print("Number of iterations: {}".format(self.pre_iterations))
-        print("Z shape: {}".format(self._Z.shape))
+        print(f"self._sklearn_pretrain: Pre-training layer {i}.")
+        print(f"self._sklearn_pretrain: n_components: {self.layers[i]}")
+        print(f"self._sklearn_pretrain: Random state: {self.seed}")
+        print(f"self._sklearn_pretrain: Number of iterations: {self.pre_iterations}")
+        print(f"self._sklearn_pretrain: Z shape: {self._Z.shape}")
 
         nmf_model = NMF(
             n_components=self.layers[i],
@@ -100,9 +101,13 @@ class DANMF(Estimator):
         """
         self._U_s = []
         self._V_s = []
+        print(f"self._pre_trainin: {self._p} layers.")
         for i in range(self._p):
+            print(f"self._pre_train: {i}th layer.")
             self._setup_z(i)
             U, V = self._sklearn_pretrain(i)
+            print(f"self._pre_training: U shape: {U.shape}")
+            print(f"self._pre_training: V shape: {V.shape}")
             self._U_s.append(U)
             self._V_s.append(V)
 

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -1,6 +1,6 @@
+import numpy as np
 import networkx as nx
 from typing import Dict, List
-import numpy as np
 from sklearn.decomposition import NMF
 
 from karateclub.estimator import Estimator

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -1,8 +1,13 @@
-import numpy as np
+import logging
+from typing import Dict, List
+
 import networkx as nx
-from typing import List, Dict
+import numpy as np
 from sklearn.decomposition import NMF
+
 from karateclub.estimator import Estimator
+
+logger = logging.getLogger(__name__)
 
 
 class DANMF(Estimator):
@@ -72,6 +77,12 @@ class DANMF(Estimator):
         Arg types:
             * **i** *(int)* - The layer index.
         """
+
+        print("Pre-training layer {}.".format(i))
+        print("Random state: {}".format(self.seed))
+        print("Number of iterations: {}".format(self.pre_iterations))
+        print("Z shape: {}".format(self._Z.shape))
+
         nmf_model = NMF(
             n_components=self.layers[i],
             init="random",

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -1,8 +1,7 @@
 import numpy as np
 import networkx as nx
-from typing import Dict, List
+from typing import List, Dict
 from sklearn.decomposition import NMF
-
 from karateclub.estimator import Estimator
 
 

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -1,6 +1,5 @@
-from typing import Dict, List
-
 import networkx as nx
+from typing import Dict, List
 import numpy as np
 from sklearn.decomposition import NMF
 

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict, List
 
 import networkx as nx
@@ -6,8 +5,6 @@ import numpy as np
 from sklearn.decomposition import NMF
 
 from karateclub.estimator import Estimator
-
-logger = logging.getLogger(__name__)
 
 
 class DANMF(Estimator):

--- a/karateclub/community_detection/overlapping/danmf.py
+++ b/karateclub/community_detection/overlapping/danmf.py
@@ -78,12 +78,6 @@ class DANMF(Estimator):
             * **i** *(int)* - The layer index.
         """
 
-        print(f"self._sklearn_pretrain: Pre-training layer {i}.")
-        print(f"self._sklearn_pretrain: n_components: {self.layers[i]}")
-        print(f"self._sklearn_pretrain: Random state: {self.seed}")
-        print(f"self._sklearn_pretrain: Number of iterations: {self.pre_iterations}")
-        print(f"self._sklearn_pretrain: Z shape: {self._Z.shape}")
-
         nmf_model = NMF(
             n_components=self.layers[i],
             init="random",
@@ -101,13 +95,9 @@ class DANMF(Estimator):
         """
         self._U_s = []
         self._V_s = []
-        print(f"self._pre_trainin: {self._p} layers.")
         for i in range(self._p):
-            print(f"self._pre_train: {i}th layer.")
             self._setup_z(i)
             U, V = self._sklearn_pretrain(i)
-            print(f"self._pre_training: U shape: {U.shape}")
-            print(f"self._pre_training: V shape: {V.shape}")
             self._U_s.append(U)
             self._V_s.append(V)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "numpy>=1.22.0",
-    "networkx==2.8.*",
+    "networkx>=3.1",
     "decorator==5.1.*",
     "pandas>=1.2.0",
     "gensim>=4.0.0",

--- a/test/community_detection_overlapping_test.py
+++ b/test/community_detection_overlapping_test.py
@@ -1,11 +1,12 @@
-import numpy as np
 import networkx as nx
+import numpy as np
+
 from karateclub.community_detection.overlapping import (
-    EgoNetSplitter,
-    NNSED,
     DANMF,
     MNMF,
+    NNSED,
     BigClam,
+    EgoNetSplitter,
     SymmNMF,
 )
 

--- a/test/community_detection_overlapping_test.py
+++ b/test/community_detection_overlapping_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import networkx as nx
-
 from karateclub.community_detection.overlapping import (
     EgoNetSplitter,
     NNSED,

--- a/test/community_detection_overlapping_test.py
+++ b/test/community_detection_overlapping_test.py
@@ -1,12 +1,12 @@
-import networkx as nx
 import numpy as np
+import networkx as nx
 
 from karateclub.community_detection.overlapping import (
+    EgoNetSplitter,
+    NNSED,
     DANMF,
     MNMF,
-    NNSED,
     BigClam,
-    EgoNetSplitter,
     SymmNMF,
 )
 


### PR DESCRIPTION
This is my PR to update dependencies [cc @benedekrozemberczki and @GiulioRossetti @WhatTheFuzz @gkirgizov ]. You can see there is one error below that remains.

I get this error in DANMF that I need to figure out. I've tried twice before having to give up as I dug into scikit-leran's NMF class. Here goes again!

```python
============================================================== test session starts ==============================================================
platform linux -- Python 3.10.11, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/rjurney/Software/karateclub
collected 6 items

test/community_detection_overlapping_test.py ..F...                                                                                       [100%]

=================================================================== FAILURES ====================================================================
__________________________________________________________________ test_danmf ___________________________________________________________________

    def test_danmf():
        """
        Test the DANMF procedure.
        """
        graph = nx.newman_watts_strogatz_graph(100, 5, 0.3)

        model = DANMF()

>       model.fit(graph)

test/community_detection_overlapping_test.py:128:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
karateclub/community_detection/overlapping/danmf.py:213: in fit
    self._pre_training()
karateclub/community_detection/overlapping/danmf.py:105: in _pre_training
    U, V = self._sklearn_pretrain(i)
karateclub/community_detection/overlapping/danmf.py:93: in _sklearn_pretrain
    U = nmf_model.fit_transform(self._Z)
../../anaconda3/envs/karateclub/lib/python3.10/site-packages/sklearn/utils/_set_output.py:140: in wrapped
    data_to_wrap = f(self, X, *args, **kwargs)
../../anaconda3/envs/karateclub/lib/python3.10/site-packages/sklearn/decomposition/_nmf.py:1568: in fit_transform
    self.reconstruction_err_ = _beta_divergence(
../../anaconda3/envs/karateclub/lib/python3.10/site-packages/sklearn/decomposition/_nmf.py:118: in _beta_divergence
    cross_prod = trace_dot((X * H.T), W)
../../anaconda3/envs/karateclub/lib/python3.10/site-packages/scipy/sparse/_base.py:584: in __mul__
    return self.multiply(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <100x100 sparse array of type '<class 'numpy.float64'>'
	with 636 stored elements in Compressed Sparse Row format>
other = array([[0.        , 0.        , 0.        , ..., 0.        , 0.        ,
        0.        ],
       [0.        , 0.  ...  ,
        0.        ],
       [0.        , 0.        , 0.        , ..., 0.14422184, 0.        ,
        0.        ]])

    def multiply(self, other):
        """Point-wise multiplication by another matrix, vector, or
        scalar.
        """
        # Scalar multiplication.
        if isscalarlike(other):
            return self._mul_scalar(other)
        # Sparse matrix or vector.
        if issparse(other):
            if self.shape == other.shape:
                other = self.__class__(other)
                return self._binopt(other, '_elmul_')
            # Single element.
            elif other.shape == (1, 1):
                return self._mul_scalar(other.toarray()[0, 0])
            elif self.shape == (1, 1):
                return other._mul_scalar(self.toarray()[0, 0])
            # A row times a column.
            elif self.shape[1] == 1 and other.shape[0] == 1:
                return self._mul_sparse_matrix(other.tocsc())
            elif self.shape[0] == 1 and other.shape[1] == 1:
                return other._mul_sparse_matrix(self.tocsc())
            # Row vector times matrix. other is a row.
            elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
                other = self._dia_container(
                    (other.toarray().ravel(), [0]),
                    shape=(other.shape[1], other.shape[1])
                )
                return self._mul_sparse_matrix(other)
            # self is a row.
            elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
                copy = self._dia_container(
                    (self.toarray().ravel(), [0]),
                    shape=(self.shape[1], self.shape[1])
                )
                return other._mul_sparse_matrix(copy)
            # Column vector times matrix. other is a column.
            elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
                other = self._dia_container(
                    (other.toarray().ravel(), [0]),
                    shape=(other.shape[0], other.shape[0])
                )
                return other._mul_sparse_matrix(self)
            # self is a column.
            elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
                copy = self._dia_container(
                    (self.toarray().ravel(), [0]),
                    shape=(self.shape[0], self.shape[0])
                )
                return copy._mul_sparse_matrix(other)
            else:
                raise ValueError("inconsistent shapes")

        # Assume other is a dense matrix/array, which produces a single-item
        # object array if other isn't convertible to ndarray.
        other = np.atleast_2d(other)

        if other.ndim != 2:
            return np.multiply(self.toarray(), other)
        # Single element / wrapped object.
        if other.size == 1:
            return self._mul_scalar(other.flat[0])
        # Fast case for trivial sparse matrix.
        elif self.shape == (1, 1):
            return np.multiply(self.toarray()[0, 0], other)

        ret = self.tocoo()
        # Matching shapes.
        if self.shape == other.shape:
            data = np.multiply(ret.data, other[ret.row, ret.col])
        # Sparse row vector times...
        elif self.shape[0] == 1:
            if other.shape[1] == 1:  # Dense column vector.
                data = np.multiply(ret.data, other)
            elif other.shape[1] == self.shape[1]:  # Dense matrix.
                data = np.multiply(ret.data, other[:, ret.col])
            else:
                raise ValueError("inconsistent shapes")
            row = np.repeat(np.arange(other.shape[0]), len(ret.row))
            col = np.tile(ret.col, other.shape[0])
            return self._coo_container(
                (data.view(np.ndarray).ravel(), (row, col)),
                shape=(other.shape[0], self.shape[1]),
                copy=False
            )
        # Sparse column vector times...
        elif self.shape[1] == 1:
            if other.shape[0] == 1:  # Dense row vector.
                data = np.multiply(ret.data[:, None], other)
            elif other.shape[0] == self.shape[0]:  # Dense matrix.
                data = np.multiply(ret.data[:, None], other[ret.row])
            else:
                raise ValueError("inconsistent shapes")
            row = np.repeat(ret.row, other.shape[1])
            col = np.tile(np.arange(other.shape[1]), len(ret.col))
            return self._coo_container(
                (data.view(np.ndarray).ravel(), (row, col)),
                shape=(self.shape[0], other.shape[1]),
                copy=False
            )
        # Sparse matrix times dense row vector.
        elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
            data = np.multiply(ret.data, other[:, ret.col].ravel())
        # Sparse matrix times dense column vector.
        elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
            data = np.multiply(ret.data, other[ret.row].ravel())
        else:
>           raise ValueError("inconsistent shapes")
E           ValueError: inconsistent shapes

../../anaconda3/envs/karateclub/lib/python3.10/site-packages/scipy/sparse/_compressed.py:471: ValueError
------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
Pre-training layer 0.
Random state: 42
Number of iterations: 100
Z shape: (100, 100)
=============================================================== warnings summary ================================================================
test/community_detection_overlapping_test.py::test_egonet_splitter
test/community_detection_overlapping_test.py::test_nnsed
test/community_detection_overlapping_test.py::test_danmf
test/community_detection_overlapping_test.py::test_bigclam
test/community_detection_overlapping_test.py::test_mnmf
test/community_detection_overlapping_test.py::test_symmnmf
  /home/rjurney/Software/karateclub/karateclub/estimator.py:63: UserWarning: Please do be advised that the graph you have provided does not contain (some) edges in the main diagonal, for instance the self-loop constitued of (0, 0). These selfloops are necessary to ensure that the graph is traversable, and for this reason we create a copy of the graph and add therein the missing edges. Since we are creating a copy, this will immediately duplicate the memory requirements. To avoid this double allocation, you can provide the graph with the selfloops.
    warnings.warn(

test/community_detection_overlapping_test.py::test_danmf
  /home/rjurney/anaconda3/envs/karateclub/lib/python3.10/site-packages/sklearn/decomposition/_nmf.py:1665: ConvergenceWarning: Maximum number of iterations 100 reached. Increase it to improve convergence.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================ short test summary info ============================================================
FAILED test/community_detection_overlapping_test.py::test_danmf - ValueError: inconsistent shapes
==================================================== 1 failed, 5 passed, 7 warnings in 1.41s ====================================================
```