### PR TITLE
SINr implementation to compute node embeddings from communities

### DIFF
--- a/examples/structral_node_embedding/sinr_example.py
+++ b/examples/structral_node_embedding/sinr_example.py
@@ -1,5 +1,5 @@
 """SINr illustrative example.
-Nodes in both cliques will get the same embedding vectors, except for the one connected to the path.
+Nodes in both cliques (barbell graph) will get the same embedding vectors, except for the ones connected to the path.
 Nodes in the paths are in distinct communities with sufficient gamma, and get thus distinct vectors.
 """
 

--- a/examples/structral_node_embedding/sinr_example.py
+++ b/examples/structral_node_embedding/sinr_example.py
@@ -1,6 +1,6 @@
 """SINr illustrative example.
-Nodes in both cliques (barbell graph) will get the same embedding vectors, except for the ones connected to the path.
-Nodes in the paths are in distinct communities with sufficient gamma, and get thus distinct vectors.
+Nodes in both cliques (barbell graph) will get the same embedding vectors, except for those connected to the path.
+Nodes in the path are in distinct communities with a high-enough gamma, and will thus get distinct vectors.
 """
 
 import networkx as nx

--- a/examples/structral_node_embedding/sinr_example.py
+++ b/examples/structral_node_embedding/sinr_example.py
@@ -1,0 +1,34 @@
+"""SINr illustrative example.
+Nodes in both cliques will get the same embedding vectors, except for the one connected to the path.
+Nodes in the paths are in distinct communities with sufficient gamma, and get thus distinct vectors.
+"""
+
+import networkx as nx
+from karateclub.node_embedding.structural import SINr
+import matplotlib.pyplot as plt
+
+def embed_and_plot(g, gamma, ax):
+    model = SINr(gamma=gamma)
+    model.fit(g)
+    X = model.get_embedding()
+
+
+    from sklearn.decomposition import PCA
+    pca = PCA(n_components=2)
+    X_2 = pca.fit_transform(X)
+
+    ax.scatter(X_2[:,0], X_2[:,1])
+    for idx, x in enumerate(X_2):
+        ax.annotate(idx, (x[0], x[1]))
+    
+    
+
+g = nx.barbell_graph(4,8)
+fig, axs = plt.subplots(3)
+
+nx.draw_kamada_kawai(g, with_labels=True, ax=axs[0])
+
+embed_and_plot(g,0.5, axs[1])
+embed_and_plot(g,10, axs[2])
+
+plt.show()

--- a/karateclub/node_embedding/structural/__init__.py
+++ b/karateclub/node_embedding/structural/__init__.py
@@ -1,2 +1,3 @@
 from .graphwave import GraphWave
 from .role2vec import Role2Vec
+from .sinr import SINr

--- a/karateclub/node_embedding/structural/sinr.py
+++ b/karateclub/node_embedding/structural/sinr.py
@@ -1,0 +1,74 @@
+from typing import Dict, List, Set
+import networkx as nx
+from karateclub.estimator import Estimator
+from scipy.sparse import coo_matrix, csr_matrix
+from sklearn.preprocessing import normalize
+import numpy as np
+
+
+class SINr(Estimator):
+    r"""An implementation of `"SINr" <https://inria.hal.science/hal-03197434/>`_
+    from the IDA '21 best paper "SINr: Fast Computing of Sparse Interpretable Node Representations is not a Sin!".
+    The procedure computes community detection using Louvain algorithm, and calculates the distribution of edges of each node
+    across communities.
+
+    Args:
+        gamma (int): modularity multi-resolution parameter. Default is 1. The higher it is, the more communities are detected, the higher the number of dimensions of the latent space uncovered.
+        seed (int): Random seed value. Default is 42.
+    """
+
+    def __init__(
+        self,
+        gamma: int = 1,
+        seed: int = 42,
+    ):
+
+        self.gamma = gamma
+        self.workers = workers
+        self.seed = seed
+        self.erase_base_features = erase_base_features
+
+
+    def fit(self, graph: nx.classes.graph.Graph):
+        """
+        Fitting a SINr model model.
+
+        Arg types:
+            * **graph** *(NetworkX graph)* - The graph to be embedded.
+        """
+        self._set_seed()
+        graph = self._check_graph(graph)
+        # Get the adjacency matrix of the graph
+        adjacency = nx.adjacency_matrix(graph)
+        norm_adjacency = normalize(adjacency, "l1") # Make rows of matrix sum at 1
+        # Detect communities use louvain algorithm with the gamma resolution parameter
+        communities = nx.community.louvain_communities(graph, resolution = self.gamma, seed = self.seed)
+        # Get the community membership of the graph
+        membership_matrix = self._get_matrix_membership(communities)
+        
+        self._embedding = norm_adjacency.dot(membership_matrix)
+        
+    def _get_matrix_membership(self, list_of_communities:List[Set[int]]):
+        r"""Getting the membership matrix describing for each node (rows), to which community (columns) it belongs.
+
+        Return types:
+            * **Membership matrix** *(scipy sparse matrix csr)* - Size nodes, communities
+        """
+        row = list()
+        col = list()
+        data = list()
+        for idx_c, community in enumerate(list_of_communities):
+            for node in community:
+                row.append(node)
+                col.append(idx_c)
+                data.append(1)
+        return coo_matrix((data, (row, col)), shape=(len(row), len(list_of_communities))).tocsr()
+        
+        
+    def get_embedding(self) -> np.array:
+        r"""Getting the node embedding.
+
+        Return types:
+            * **embedding** *(Numpy array)* - The embedding of nodes.
+        """
+        return self._embedding.toarray()

--- a/karateclub/node_embedding/structural/sinr.py
+++ b/karateclub/node_embedding/structural/sinr.py
@@ -15,7 +15,7 @@ class SINr(Estimator):
 
     Args:
         gamma (int): modularity multi-resolution parameter. Default is 1. 
-        The dimensions parameter does not exist for SINr, gamma should be use instead: the numbers of dimensions of the embedding space is based on the number of communities uncovered. The higher gamma is, the more communities are detected, the higher the number of dimensions of the latent space uncovered. For small graphs, setting gamma to 1 is usually a good fit. For bigger graphs, it is recommended to increase gamma (5 or 10 for instance). For word co-occurrence graphs, to deal with word embedding, gamma is isually set to 50 to get a lot of small communities.
+        The dimension parameter does not exist for SINr, gamma should be use instead: the number of dimensions of the embedding space is based on the number of communities uncovered. The higher gamma is, the more communities are detected, the higher the number of dimensions of the latent space uncovered. For small graphs, setting gamma to 1 is usually a good fit. For bigger graphs, it is recommended to increase gamma (5 or 10 for instance). For word co-occurrence graphs, to deal with word embedding, gamma is isually set to 50 to get a lot of small communities.
         seed (int): Random seed value. Default is 42.
     """
 
@@ -31,7 +31,7 @@ class SINr(Estimator):
 
     def fit(self, graph: nx.classes.graph.Graph):
         """
-        Fitting a SINr model model.
+        Fitting a SINr model.
 
         Arg types:
             * **graph** *(NetworkX graph)* - The graph to be embedded.

--- a/karateclub/node_embedding/structural/sinr.py
+++ b/karateclub/node_embedding/structural/sinr.py
@@ -9,13 +9,12 @@ import numpy as np
 class SINr(Estimator):
     r"""An implementation of `"SINr" <https://inria.hal.science/hal-03197434/>`_
     from the IDA '21 best paper "SINr: Fast Computing of Sparse Interpretable Node Representations is not a Sin!".
-    The procedure computes community detection using Louvain algorithm, and calculates the distribution of edges of each node across communities.
-    The algorithm is one of the fastest, because it relies mostly on Louvain community detection. It thus runs in 
-    quasi-linear time. Regarding space complexity, it requires to be able to store the adjacency matrix and the community membership matrix, it is also quasi-linear.
+    The procedure performs community detection using the Louvain algorithm, and computes the distribution of edges of each node across all communities.
+    The algorithm is one of the fastest, because it mostly relies on Louvain community detection. It thus runs in quasi-linear time. Regarding space complexity, the adjacency matrix and the community membership matrix need to be stored, it is also quasi-linear.
 
     Args:
         gamma (int): modularity multi-resolution parameter. Default is 1. 
-        The dimension parameter does not exist for SINr, gamma should be use instead: the number of dimensions of the embedding space is based on the number of communities uncovered. The higher gamma is, the more communities are detected, the higher the number of dimensions of the latent space uncovered. For small graphs, setting gamma to 1 is usually a good fit. For bigger graphs, it is recommended to increase gamma (5 or 10 for instance). For word co-occurrence graphs, to deal with word embedding, gamma is isually set to 50 to get a lot of small communities.
+        The dimension parameter does not exist for SINr, gamma should be used instead: the number of dimensions of the embedding space is based on the number of communities uncovered. The higher gamma is, the more communities are detected, the higher the number of dimensions of the latent space are uncovered. For small graphs, setting gamma to 1 is usually sufficient. For bigger graphs, it is recommended to increase gamma (5 or 10 for example). For word co-occurrence graphs, to deal with word embedding, gamma is usually set to 50  in order to get many small communities.
         seed (int): Random seed value. Default is 42.
     """
 
@@ -50,7 +49,7 @@ class SINr(Estimator):
         self._embedding = norm_adjacency.dot(membership_matrix)
         
     def _get_matrix_membership(self, list_of_communities:List[Set[int]]):
-        r"""Getting the membership matrix describing for each node (rows), to which community (columns) it belongs.
+        r"""Getting the membership matrix describing for each node (rows), in which community (column) it belongs.
 
         Return types:
             * **Membership matrix** *(scipy sparse matrix csr)* - Size nodes, communities

--- a/test/structral_node_embedding_test.py
+++ b/test/structral_node_embedding_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 import networkx as nx
-from karateclub import Role2Vec, GraphWave
+from karateclub import Role2Vec, GraphWave, SINr
 
 
 def test_role2vec():
@@ -72,4 +72,37 @@ def test_graphwave():
 
     assert embedding.shape[0] == graph.number_of_nodes()
     assert embedding.shape[1] == 2 * model.sample_number
+    assert type(embedding) == np.ndarray
+    
+
+
+def test_sinr():
+    """
+    Testing the SINr class.
+    """
+    model = SINr()
+
+    graph = nx.watts_strogatz_graph(100, 10, 0.5)
+
+    model.fit(graph)
+
+    embedding = model.get_embedding()
+
+    assert embedding.shape[0] == graph.number_of_nodes()
+    assert embedding.shape[1] == model.dimensions
+    assert type(embedding) == np.ndarray
+
+    model = SINr(gamma=5)
+
+    graph = nx.watts_strogatz_graph(200, 10, 0.5)
+
+    model.fit(graph)
+
+    embedding = model.get_embedding()
+
+    assert embedding.shape[0] == graph.number_of_nodes()
+    assert embedding.shape[1] == model.dimensions
+    model2 = SINr(gamma=10)
+    model2.fit(graph)
+    assert model2.dimensions > model.dimensions
     assert type(embedding) == np.ndarray


### PR DESCRIPTION
As fans of the karateclub package, we propose to add the implementation of SINr, a graph embedding approach based on community detection to the package. 
SINr was first published in : 
Thibault Prouteau, Victor Connes, Nicolas Dugué, Anthony Perez, Jean-Charles Lamirel, et al.. SINr: Fast Computing of Sparse Interpretable Node Representations is not a Sin!. Advances in Intelligent Data Analysis XIX, 19th International Symposium on Intelligent Data Analysis, IDA 2021. pp.325-337, ⟨[10.1007/978-3-030-74251-5_26](https://dx.doi.org/10.1007/978-3-030-74251-5_26)⟩. [⟨hal-03197434⟩](https://hal.science/hal-03197434)

It allows to produce interpretable node representations and can also compute word embeddings on textual graph data : 
Béranger, A., Dugué, N., Guillot, S., & Prouteau, T. (2023, November). Filtering communities in word co-occurrence networks to foster the emergence of meaning. In International Conference on Complex Networks and Their Applications (pp. 377-388).

A complete SINr implementation can be found here : https://github.com/SINr-Embeddings/sinr
But the code we provide in this pull request is enough to train efficiently node embeddings using networkx and scipy.
We would really appreciate our method to be included in the karateclub package that we use a lot !