### PR TITLE
The `scipy.linalg` function `triu` was removed in SciPy 1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "tqdm",
     "python-louvain",
     "scikit-learn",
-    "scipy",
+    "scipy<1.13",
     "pygsp",
     "six",
     "python-Levenshtein"


### PR DESCRIPTION
To import `from karateclub import GraphReader` it is necessary to import `from scipy.linalg import triu` (see the Traceback bellow):

```
(.venv)  ± python scripts/karate.py
Traceback (most recent call last):
  File "/path/to/project/scripts/karate.py", line 2, in <module>
    from karateclub import GraphReader
  File "/path/to/project/.venv/lib/python3.11/site-packages/karateclub/__init__.py", line 2, in <module>
    from karateclub.node_embedding import *
  File "/path/to/project/.venv/lib/python3.11/site-packages/karateclub/node_embedding/__init__.py", line 1, in <module>
    from .neighbourhood import *
  File "/path/to/project/.venv/lib/python3.11/site-packages/karateclub/node_embedding/neighbourhood/__init__.py", line 2, in <module>
    from .deepwalk import DeepWalk
  File "/path/to/project/.venv/lib/python3.11/site-packages/karateclub/node_embedding/neighbourhood/deepwalk.py", line 3, in <module>
    from gensim.models.word2vec import Word2Vec
  File "/path/to/project/.venv/lib/python3.11/site-packages/gensim/__init__.py", line 11, in <module>
    from gensim import parsing, corpora, matutils, interfaces, models, similarities, utils  # noqa:F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/project/.venv/lib/python3.11/site-packages/gensim/corpora/__init__.py", line 6, in <module>
    from .indexedcorpus import IndexedCorpus  # noqa:F401 must appear before the other classes
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/project/.venv/lib/python3.11/site-packages/gensim/corpora/indexedcorpus.py", line 14, in <module>
    from gensim import interfaces, utils
  File "/path/to/project/.venv/lib/python3.11/site-packages/gensim/interfaces.py", line 19, in <module>
    from gensim import utils, matutils
  File "/path/to/project/.venv/lib/python3.11/site-packages/gensim/matutils.py", line 20, in <module>
    from scipy.linalg import get_blas_funcs, triu
ImportError: cannot import name 'triu' from 'scipy.linalg' (/path/to/project/.venv/lib/python3.11/site-packages/scipy/linalg/__init__.py)
User at Device in /path/to/project on main!
```

But since the `scipy.linalg` function `triu` was removed in SciPy 1.13, to make it work, we need "scipy<1.13". Therefore the modification on the `setup.py` file.

See details on this StackOverflow question:
https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-when-importing-gens